### PR TITLE
Enable apisnoop to be deployed to a cluster

### DIFF
--- a/config/audit/policy.yaml
+++ b/config/audit/policy.yaml
@@ -1,0 +1,8 @@
+# audit-policy.yaml
+
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: Metadata
+    stages:
+      - ResponseComplete

--- a/config/audit/sink.yaml
+++ b/config/audit/sink.yaml
@@ -1,0 +1,17 @@
+# audit-sink.yaml
+# Currently hardcoded. Would be good if we had dynamic.
+
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: http://127.0.0.1:9900/events
+  name: auditsink-cluster
+contexts:
+- context:
+    cluster: auditsink-cluster
+    user: ""
+  name: auditsink-context
+current-context: auditsink-context
+users: []
+preferences: {}

--- a/config/kind-apisnoop-cni-disable.yaml
+++ b/config/kind-apisnoop-cni-disable.yaml
@@ -1,0 +1,28 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta3
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "audit-webhook-config-file": "/etc/kubernetes/pki/audit/sink.yaml"
+        "audit-policy-file": "/etc/kubernetes/pki/audit/policy.yaml"
+networking:
+  # the default CNI will not be installed
+  disableDefaultCNI: true
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: audit
+        containerPath: /etc/kubernetes/pki/audit
+        readOnly: True
+      - hostPath: manifests/apisnoop.yaml
+        containerPath: /etc/kubernetes/manifests/apisnoop.yaml
+        readOnly: True
+    extraPortMappings:
+      - containerPort: 5432
+        hostPort: 5432
+  - role: worker

--- a/config/kind-apisnoop-cni-enable.yaml
+++ b/config/kind-apisnoop-cni-enable.yaml
@@ -1,0 +1,25 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta3
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "audit-webhook-config-file": "/etc/kubernetes/pki/audit/sink.yaml"
+        "audit-policy-file": "/etc/kubernetes/pki/audit/policy.yaml"
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: audit
+        containerPath: /etc/kubernetes/pki/audit
+        readOnly: True
+      - hostPath: manifests/apisnoop.yaml
+        containerPath: /etc/kubernetes/manifests/apisnoop.yaml
+        readOnly: True
+    extraPortMappings:
+      - containerPort: 5432
+        hostPort: 5432
+  - role: worker

--- a/config/manifests/apisnoop.yaml
+++ b/config/manifests/apisnoop.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "apisnoop"
+  labels:
+    app.kubernetes.io/name: apisnoop
+    app: apisnoop
+spec:
+  hostname: apisnoop
+  hostNetwork: true
+  # a mirror pod may not reference service accounts
+  # serviceAccountName: default
+  securityContext: {}
+  volumes:
+    - name: tmp
+      emptyDir: {}
+    - name: var-lib-postgresql
+      emptyDir: {}
+    - name: var-run-postgresql
+      emptyDir: {}
+  containers:
+    - name: snoopdb
+      image: "gcr.io/k8s-staging-apisnoop/snoopdb:v20240121-auditlogger-1.2.11-4-gb17b29c"
+      imagePullPolicy: IfNotPresent
+      ports:
+        - containerPort: 5432
+      env:
+        - name: POSTGRES_DB
+          value: apisnoop
+        - name: POSTGRES_USER
+          value: apisnoop
+        - name: PGDATABASE
+          value: apisnoop
+        - name: PGUSER
+          value: apisnoop
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: trust
+      livenessProbe:
+        exec:
+          command:
+            - "sh"
+            - "-c"
+            - "pg_isready"
+            - "-U"
+            - "$POSTGRES_USER"
+        failureThreshold: 5
+        periodSeconds: 10
+        timeoutSeconds: 5
+      resources: {}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: var-lib-postgresql
+          mountPath: /var/lib/postgresql
+        - name: var-run-postgresql
+          mountPath: /var/run/postgresql
+    - name: auditlogger
+      image: "gcr.io/k8s-staging-apisnoop/auditlogger:v20210824-0.2.0-70-g0faa7b3"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: APP_DB_CONNECTION_STRING
+          value: postgres://apisnoop:apisnoop@localhost/apisnoop?sslmode=disable
+        - name: APP_DB_AUDIT_EVENT_TABLE
+          value: testing.audit_event
+        - name: APP_PORT
+          value: "9900"
+        - name: APP_DISABLE_LOGS
+          value: "false"
+      ports:
+        - name: http
+          containerPort: 9900
+          protocol: TCP
+      livenessProbe:
+        httpGet:
+          path: /
+          port: http
+      readinessProbe:
+        httpGet:
+          path: /
+          port: http
+      resources: {}

--- a/deploy-kind-gtw-api-cluster.sh
+++ b/deploy-kind-gtw-api-cluster.sh
@@ -20,6 +20,10 @@ export KIND_NET=${KIND_NET:-"kind"}
 export KIND_DISABLE_CNI=${KIND_DISABLE_CNI:-"false"}
 export KIND_DISABLE_CNI=${KIND_DISABLE_CNI,,}
 
+export ENABLE_APISNOOP=${ENABLE_APISNOOP:-"false"}
+export ENABLE_APISNOOP=${ENABLE_APISNOOP,,}
+echo "ENABLE_APISNOOP: ${ENABLE_APISNOOP}"
+
 echo "CONFIG_DIR: ${CONFIG_DIR}"
 
 source "./lib/init.sh"

--- a/lib/kind.sh
+++ b/lib/kind.sh
@@ -6,10 +6,9 @@ deploy::kind() {
   echo "deploy::kind"
   config::kind::config
 
-  # ERROR: failed to create cluster: node(s) already exist for a cluster with the name "kind"
-  # ^^^ Check
-
+  cd $(dirname ${KIND_CONFIG}) || exit
   kind create cluster --config=${KIND_CONFIG} --image=${KIND_IMAGE}
+  cd - || exit
 }
 
 
@@ -18,12 +17,8 @@ config::kind::config() {
   echo "KIND_DISABLE_CNI: ${KIND_DISABLE_CNI}"
   case ${KIND_DISABLE_CNI} in
 
-    "true")
-      export KIND_CONFIG=${CONFIG_DIR}/kind-cni-disable.yaml
-      ;;
-
-    "false")
-      export KIND_CONFIG=${CONFIG_DIR}/kind-cni-enable.yaml
+    "true" | "false")
+      config::kind::${ENABLE_APISNOOP}::${KIND_DISABLE_CNI}
       ;;
 
     *)
@@ -32,7 +27,25 @@ config::kind::config() {
       ;;
   esac
 
+  echo "KIND_CONFIG: ${KIND_CONFIG}"
   echo "KIND_IMAGE: ${KIND_IMAGE}"
+}
+
+# config::kind::ENABLE_APISNOOP::KIND_DISABLE_CNI
+config::kind::false::false() {
+      export KIND_CONFIG=${CONFIG_DIR}/kind-cni-enable.yaml
+}
+
+config::kind::false::true() {
+      export KIND_CONFIG=${CONFIG_DIR}/kind-cni-disable.yaml
+}
+
+config::kind::true::false() {
+      export KIND_CONFIG=${CONFIG_DIR}/kind-apisnoop-cni-enable.yaml
+}
+
+config::kind::true::true() {
+      export KIND_CONFIG=${CONFIG_DIR}/kind-apisnoop-cni-disable.yaml
 }
 
 check::kind::cni() {


### PR DESCRIPTION
Fixes: #1

```
$ export ENABLE_APISNOOP=true
$ export GATEWAY_API_VERSION=v1.0.0
$ ./deploy-kind-gtw-api-cluster.sh
IMPLEMENTATION: cilium
ENABLE_APISNOOP: true
...
config::implementation
deploy::cilium::gatewayclass
Warning: resource gatewayclasses/cilium is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
gatewayclass.gateway.networking.k8s.io/cilium configured
NAME     CONTROLLER                     ACCEPTED   AGE
cilium   io.cilium/gateway-controller   True       2m28s
{
  "conditions": [
    {
      "lastTransitionTime": "2024-05-30T23:58:14Z",
      "message": "Valid GatewayClass",
      "observedGeneration": 1,
      "reason": "Accepted",
      "status": "True",
      "type": "Accepted"
    }
  ],
  "supportedFeatures": [
    "Gateway",
    "HTTPRoute",
    "HTTPRouteDestinationPortMatching",
    "HTTPRouteHostRewrite",
    "HTTPRouteMethodMatching",
    "HTTPRoutePathRedirect",
    "HTTPRoutePathRewrite",
    "HTTPRoutePortRedirect",
    "HTTPRouteQueryParamMatching",
    "HTTPRouteRequestMirror",
    "HTTPRouteRequestMultipleMirrors",
    "HTTPRouteResponseHeaderModification",
    "HTTPRouteSchemeRedirect",
    "ReferenceGrant",
    "TLSRoute"
  ]
}
```
check what's running in the cluster
```
$ kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
default              apisnoop-kind-control-plane                  2/2     Running   0          21m
kube-system          cilium-chlkm                                 1/1     Running   0          21m
kube-system          cilium-operator-64664858c8-tsgfc             1/1     Running   0          21m
kube-system          cilium-operator-64664858c8-w2ww9             1/1     Running   0          21m
kube-system          cilium-rvkr5                                 1/1     Running   0          21m
kube-system          coredns-7db6d8ff4d-gxm44                     1/1     Running   0          21m
kube-system          coredns-7db6d8ff4d-ng8x6                     1/1     Running   0          21m
kube-system          etcd-kind-control-plane                      1/1     Running   0          21m
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          21m
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          21m
kube-system          kube-proxy-nppxl                             1/1     Running   0          21m
kube-system          kube-proxy-zvqlw                             1/1     Running   0          21m
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          21m
local-path-storage   local-path-provisioner-988d74bc-kcn2q        1/1     Running   0          21m
metallb-system       metallb-controller-776b9fff94-9q6v6          1/1     Running   0          19m
metallb-system       metallb-speaker-dgb84                        1/1     Running   0          19m
```

run the gateway-api conformance tests
```
$ ./run-conformance-suite.sh 
```
get the event count from snoopdb
```
$ export PGUSER=apisnoop ; export PGHOST=127.0.0.1 ; psql
psql (16.3 (Ubuntu 16.3-1.pgdg20.04+1), server 15.5 (Debian 15.5-1.pgdg110+1))
Type "help" for help.

apisnoop=# select count(*) from testing.audit_event where useragent ilike '%gateway-api.test%';
 count 
-------
  7560
(1 row)
```