### PR TITLE
Add missing 'run::contour::conformance'

### DIFF
--- a/implementation/contour.sh
+++ b/implementation/contour.sh
@@ -33,6 +33,11 @@ EOF
 
 }
 
+run::contour::conformance() {
+  echo "run::contour::conformance"
+  run::contour::gateway-api-conformance
+}
+
 run::contour::gateway-api-conformance() {
   echo "run::contour::gateway-api-conformance"
 

--- a/implementation/contour.sh
+++ b/implementation/contour.sh
@@ -32,3 +32,45 @@ spec:
 EOF
 
 }
+
+run::contour::gateway-api-conformance() {
+  echo "run::contour::gateway-api-conformance"
+
+  export GATEWAY_API_REPO_PATH=${GATEWAY_API_REPO_PATH:-"${PWD}/repos/gateway-api}"}
+  if [[ ! -d ${GATEWAY_API_REPO_PATH} ]]; then
+    echo "GATEWAY_API_REPO_PATH: ${GATEWAY_API_REPO_PATH}"
+    echo "Repo doesn't exists, cloning repo"
+
+    mkdir -p repos
+    cd $_ || exit
+    git clone https://github.com/kubernetes-sigs/gateway-api.git
+    cd - || exit
+  fi
+  pushd repos/gateway-api/conformance || exit 1
+
+  git checkout ${GATEWAY_API_VERSION}
+
+  SUPPORTED_FEATURES="Gateway,HTTPRoute"
+  SKIP_TESTS="Mesh"
+  CURRENT_DATE_TIME=$(date +"%Y%m%d-%H%M")
+  REPORT="/tmp/conformance-suite-report-${CURRENT_DATE_TIME}-contour.yaml"
+
+  GATEWAY_API_CONFORMANCE_TESTS=1 go test \
+    -p 4 \
+    --gateway-class contour \
+    --supported-features "${SUPPORTED_FEATURES}" \
+    --report-output=${REPORT} \
+    --organization=projectcontour \
+    --project=contour \
+    --url=https://projectcontour.io/ \
+    --version=v1.29.0 \
+    --contact='@projectcontour/maintainers' \
+    -test.run "TestConformance" \
+    -test.skip "${SKIP_TESTS}" \
+    -test.v 10
+
+  popd || exit
+
+  echo -e "\n\nConformance Suite completed.\n${IMPLEMENTATION} report saved: ${REPORT}.\n\n"
+  cat "${REPORT}"
+}


### PR DESCRIPTION
Fixes: #31 

```
run::contour::conformance() {
  echo "run::contour::conformance"
  run::contour::gateway-api-conformance
}
```
`run::contour::gateway-api-conformance`  
- checks out the gateway-api repo
- switches to the tag release of `GATEWAY_API_VERSION`
- runs conformance tests
ref: https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/conformance_test.go