### PR TITLE
disable kubeproxy when deploying cilium

### DIFF
--- a/config/kind-apisnoop-cni-disable.yaml
+++ b/config/kind-apisnoop-cni-disable.yaml
@@ -13,6 +13,7 @@ kubeadmConfigPatches:
 networking:
   # the default CNI will not be installed
   disableDefaultCNI: true
+  kubeProxyMode: "none"
 nodes:
   - role: control-plane
     extraMounts:

--- a/config/kind-cni-disable.yaml
+++ b/config/kind-cni-disable.yaml
@@ -3,6 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   # the default CNI will not be installed
   disableDefaultCNI: true
+  kubeProxyMode: "none"
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
Fixes: #53 

```
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
default              apisnoop-kind-control-plane                  2/2     Running   0          18m
kube-system          cilium-j8kq7                                 1/1     Running   0          17m
kube-system          cilium-operator-7f998659cc-kxxn9             1/1     Running   0          17m
kube-system          cilium-operator-7f998659cc-sgrm4             1/1     Running   0          17m
kube-system          cilium-zkpr5                                 1/1     Running   0          17m
kube-system          coredns-7db6d8ff4d-7pk69                     1/1     Running   0          17m
kube-system          coredns-7db6d8ff4d-rmwgc                     1/1     Running   0          17m
kube-system          etcd-kind-control-plane                      1/1     Running   0          18m
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          18m
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          18m
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          18m
local-path-storage   local-path-provisioner-988d74bc-zts6k        1/1     Running   0          17m
metallb-system       metallb-controller-776b9fff94-dghmf          1/1     Running   0          16m
metallb-system       metallb-speaker-h84kv                        1/1     Running   0          16m
```