### PR TITLE
chore: use cloud-provider=external with kind

### DIFF
--- a/config/kind-apisnoop-cni-disable.yaml
+++ b/config/kind-apisnoop-cni-disable.yaml
@@ -6,16 +6,30 @@ kubeadmConfigPatches:
     kind: ClusterConfiguration
     metadata:
       name: config
+    controllerManager:
+      extraArgs:
+        cloud-provider: "external"
     apiServer:
       extraArgs:
         "audit-webhook-config-file": "/etc/kubernetes/policies/sink.yaml"
         "audit-policy-file": "/etc/kubernetes/policies/policy.yaml"
+        cloud-provider: "external"
       extraVolumes:
         - name: audit-policies
           hostPath: /etc/kubernetes/policies
           mountPath: /etc/kubernetes/policies
           readOnly: true
           pathType: "DirectoryOrCreate"
+    ---
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: "external"
+    ---
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: "external"
 networking:
   # the default CNI will not be installed
   disableDefaultCNI: true

--- a/config/kind-apisnoop-cni-enable.yaml
+++ b/config/kind-apisnoop-cni-enable.yaml
@@ -6,16 +6,30 @@ kubeadmConfigPatches:
     kind: ClusterConfiguration
     metadata:
       name: config
+    controllerManager:
+      extraArgs:
+        cloud-provider: "external"
     apiServer:
       extraArgs:
         "audit-webhook-config-file": "/etc/kubernetes/policies/sink.yaml"
         "audit-policy-file": "/etc/kubernetes/policies/policy.yaml"
+        cloud-provider: "external"
       extraVolumes:
         - name: audit-policies
           hostPath: /etc/kubernetes/policies
           mountPath: /etc/kubernetes/policies
           readOnly: true
           pathType: "DirectoryOrCreate"
+    ---
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: "external"
+    ---
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: "external"
 nodes:
   - role: control-plane
     extraMounts:

--- a/config/kind-cni-disable.yaml
+++ b/config/kind-cni-disable.yaml
@@ -1,5 +1,27 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta3
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    controllerManager:
+      extraArgs:
+        cloud-provider: "external"
+    apiServer:
+      extraArgs:
+        cloud-provider: "external"
+    ---
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: "external"
+    ---
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: "external"
 networking:
   # the default CNI will not be installed
   disableDefaultCNI: true

--- a/config/kind-cni-enable.yaml
+++ b/config/kind-cni-enable.yaml
@@ -1,5 +1,27 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta3
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    controllerManager:
+      extraArgs:
+        cloud-provider: "external"
+    apiServer:
+      extraArgs:
+        cloud-provider: "external"
+    ---
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: "external"
+    ---
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: "external"
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
enable use of cloud-provider-kind especially LoadBalancing on non-Linux platform