### PR TITLE
chore: use auditsink ip for sink

### DIFF
--- a/config/audit/sink.yaml
+++ b/config/audit/sink.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-    server: http://127.0.0.1:9900/events
+    server: http://10.96.96.96:9900/events
   name: auditsink-cluster
 contexts:
 - context:


### PR DESCRIPTION
use fixed clusterip instead of localhost