### PR TITLE
Don't stop suite run if gateway-api repo already cloned

### DIFF
--- a/implementation/contour.sh
+++ b/implementation/contour.sh
@@ -49,7 +49,7 @@ run::contour::gateway-api-conformance() {
 
     mkdir -p repos
     cd $_ || exit
-    git clone https://github.com/kubernetes-sigs/gateway-api.git
+    git clone https://github.com/kubernetes-sigs/gateway-api.git || true
     cd - || exit
   fi
   pushd repos/gateway-api/conformance || exit 1


### PR DESCRIPTION
Fixes: #63 