### PR TITLE
fix mismatch istio install

### DIFF
--- a/implementation/istio.sh
+++ b/implementation/istio.sh
@@ -5,7 +5,9 @@ export IMPLEMENTATION_VERSION=${IMPLEMENTATION_VERSION:-"1.22.1"}
 deploy::istio() {
   echo "deploy::istio"
 
-  istioctl install --set profile=minimal --set tag="${IMPLEMENTATION_VERSION}" --skip-confirmation
+  kubectl create ns istio-system
+  helm install istio-base istio/base -n istio-system --set defaultRevision=default --version "${IMPLEMENTATION_VERSION}"
+  helm install istiod istio/istiod -n istio-system --version "${IMPLEMENTATION_VERSION}" --wait
 
   cat << EOF | kubectl apply -f -
 apiVersion: gateway.networking.k8s.io/v1beta1


### PR DESCRIPTION
Fixes: #65 

```
$ kubectl -n istio-system get pod istiod-fcb47fd9d-h9ds2 -ojsonpath={'.spec.containers[].image'}
docker.io/istio/pilot:1.20.8
```

```
$ kubectl get gtw
NAME      CLASS   ADDRESS          PROGRAMMED   AGE
example   istio   172.21.255.200   True         9m6s
```
