### PR TITLE
Address missing conformance report

### DIFF
--- a/implementation/cilium.sh
+++ b/implementation/cilium.sh
@@ -92,6 +92,5 @@ run::cilium::conformance() {
 
   popd || exit
 
-  echo -e "\n\nConformance Suite completed.\n${IMPLEMENTATION} report saved: ${REPORT}.\n\n"
-  cat "${REPORT}"
+  print::report
 }

--- a/implementation/contour.sh
+++ b/implementation/contour.sh
@@ -77,6 +77,5 @@ run::contour::gateway-api-conformance() {
 
   popd || exit
 
-  echo -e "\n\nConformance Suite completed.\n${IMPLEMENTATION} report saved: ${REPORT}.\n\n"
-  cat "${REPORT}"
+  print::report
 }

--- a/implementation/envoy-gateway.sh
+++ b/implementation/envoy-gateway.sh
@@ -56,6 +56,5 @@ run::envoy-gateway::gateway-api-conformance() {
 
   popd || exit
 
-  echo -e "\n\nConformance Suite completed.\n${IMPLEMENTATION} report saved: ${REPORT}.\n\n"
-  cat "${REPORT}"
+  print::report
 }

--- a/implementation/istio.sh
+++ b/implementation/istio.sh
@@ -64,6 +64,5 @@ run::istio::conformance() {
 
   popd || exit
 
-  echo -e "\n\nConformance Suite completed.\n${IMPLEMENTATION} report saved: ${REPORT}.\n\n"
-  cat "${REPORT}"
+  print::report
 }

--- a/run-conformance-suite.sh
+++ b/run-conformance-suite.sh
@@ -18,4 +18,15 @@ source "./lib/init.sh"
 
 export GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.1.0}"
 
+function print::report() {
+  echo -e "\n\nConformance suite completed."
+  REPORT=${REPORT:-}
+  if [[ -f "${REPORT}" ]]; then
+    echo -e "${IMPLEMENTATION} report saved: ${REPORT}.\n\n"
+    cat "${REPORT}"
+  else
+    echo -e "${IMPLEMENTATION} report '${REPORT}' not saved.\n\n"
+  fi
+}
+
 run::${IMPLEMENTATION}::conformance


### PR DESCRIPTION
Fixes: #69 

```
PASS
ok  	github.com/cilium/cilium/operator/pkg/gateway-api	59.259s
~/repos/github/apisnoop/gateway-api-test-framework


Conformance suite completed.
cilium report '/tmp/conformance-suite-report-20240722-1034-cilium.yaml' not saved.
```

This means that [run-conformance-suite.sh](https://github.com/apisnoop/gateway-api-test-framework/blob/main/run-conformance-suite.sh) has a clean exit now.